### PR TITLE
Corrección de error en campo Dirección de modal actualizar

### DIFF
--- a/components/modals/editUserModal.js
+++ b/components/modals/editUserModal.js
@@ -200,7 +200,7 @@ function EditUserModal({ open, user, onClose, onUpdate }) {
                 {...register("address", {
                   required: "La dirección es obligatorio",
                   pattern: {
-                    value: /^([a-zA-Z0-9]+\s)+\d+(\s\w+)?\s?#\s?\d+$/,
+                    value: /^[\w\s\.,#áéíóúüñÁÉÍÓÚÜÑ-]+$/,
                     message:"Ingresa una dirección valida",
                   },
                 })}


### PR DESCRIPTION
Se modificó la expresión regular del campo dirección, ya que no aceptaba direcciones diferentes a la estructura "Calle 6 Norte # 11"